### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,12 +31,6 @@ jobs:
           extra_features: macos-extra-features
           build_time_dependencies: |
             brew install sdl2
-        # NOTE: `macos-13` uses the x86/64 architecture:
-        # https://github.com/actions/runner-images
-        - os: macos-13
-          extra_features: macos-extra-features
-          build_time_dependencies: |
-            brew install sdl2
     runs-on: ${{ matrix.platform.os }}
 
     env:

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ check:
 .PHONY: check
 
 package-release: cargo-all-tests
-	cargo install cargo-about --version "0.6.1"
+	cargo install cargo-about --version "0.6.6"
 	cargo about generate --no-default-features --features "prod ${EXTRA_FEATURES}" about.hbs --output-file third-party-licenses.html
 	cargo build --release --no-default-features --features "prod ${EXTRA_FEATURES}"
 	rm -rf target/out target/package.zip


### PR DESCRIPTION
Remove the `macos-13` (it's been retired and it's no longer available) and update `cargo-about` to fix the current failures.