### PR TITLE
CI: fix sdl2-related issues on Windows and Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,15 +22,21 @@ jobs:
           build_time_dependencies: |
             sudo apt-get update
             sudo apt-get install libasound2-dev libudev-dev libfontconfig-dev libsdl2-dev
+          sys_dependencies: ""
         - os: windows-2025
           extra_features: windows-extra-features
           build_time_dependencies: ""
+          sys_dependencies: |
+            "C:\Program Files\Microsoft Visual Studio\18\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+            $Env:CMAKE_GENERATOR = "Visual Studio 18 2026"
+            $Env:CMAKE_POLICY_VERSION_MINIMUM = "3.5"
         # NOTE: `macos-latest` uses the Arm64 architecture:
         # https://github.com/actions/runner-images
         - os: macos-14
           extra_features: macos-extra-features
           build_time_dependencies: |
             brew install sdl2
+          sys_dependencies: ""
     runs-on: ${{ matrix.platform.os }}
 
     env:
@@ -54,4 +60,7 @@ jobs:
     - name: Install Rust Nightly
       run: "rustup install nightly"
     - name: Check, build and upload the release
-      run: "make package-release"
+      run: |
+        ${{ matrix.platform.sys_dependencies }}
+
+        make package-release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           extra_features: linux-extra-features
           build_time_dependencies: |
             sudo apt-get update
-            sudo apt-get install libasound2-dev libudev-dev libfontconfig-dev
+            sudo apt-get install libasound2-dev libudev-dev libfontconfig-dev libsdl2-dev
         - os: windows-2025
           extra_features: windows-extra-features
           build_time_dependencies: ""

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,7 @@ sdl2 = { version = "0.38", features = ["bundled"] }
 [target.'cfg(target_os="linux")'.dependencies]
 # NOTE: only a single version of SDL can be compiled in at a time, it seems
 #sdl3 = { version = "0.14.36", features = ["build-from-source"] }
-sdl2 = { version = "0.38", features = ["bundled"] }
+sdl2 = { version = "0.38" }
 
 
 [features]


### PR DESCRIPTION
This is having build linking issues on my linux desktop but I know how to fix those locally. I want to see what it looks like on the CI without making any changes there.

I know SDL docs recommend you link the system library dynamically to benefit from fixes and improvements.

Let's get some data on what that actually looks like.