### PR TITLE
Remove `PartialOrd` comparison for `Point`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,3 +190,4 @@ undocumented_unsafe_blocks = "deny"
 # Worth reconsidering at some point, but keeping commented out for now.
 #indexing_slicing = "deny"
 #unreachable = "deny"
+unimplemented = "deny"

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -652,7 +652,7 @@ impl Display {
     /// `screen_size_px`: dimension of the game window in logical pixels.
     /// `tilesize`: size (in pixels) of a single tile. Tiles are square.
     pub fn new(screen_size_px: Point, tile_size: i32, text_size: i32) -> Self {
-        assert!(screen_size_px > Point::zero());
+        assert!(screen_size_px.is_positive());
         assert!(tile_size > 0);
         assert!(text_size > 0);
         // NOTE: this padding is only here to make the screen scroll smoothly.
@@ -826,7 +826,7 @@ impl Display {
         let display_size_px = self.display_size * self.tile_size;
 
         if let Some(bg) = self.clear_background_color {
-            let full_screen_rect = Rectangle::from_point_and_size(Point::zero(), display_size_px);
+            let full_screen_rect = Rectangle::from_size(display_size_px);
             drawcalls.push(Drawcall::Rectangle(full_screen_rect, bg.into()));
         }
 
@@ -1040,7 +1040,7 @@ impl Display {
         drawcalls.extend(self.drawcalls.iter());
 
         if self.fade.alpha > 0 {
-            let full_screen_rect = Rectangle::from_point_and_size(Point::zero(), display_size_px);
+            let full_screen_rect = Rectangle::from_size(display_size_px);
             drawcalls.push(Drawcall::Rectangle(full_screen_rect, self.fade));
         }
     }

--- a/src/engine/glutin.rs
+++ b/src/engine/glutin.rs
@@ -9,6 +9,7 @@ use crate::{
     },
     formula, keys,
     point::Point,
+    rect::Rectangle,
     settings::{MIN_WINDOW_HEIGHT, MIN_WINDOW_WIDTH, Store as SettingsStore},
     state::State,
 };
@@ -275,6 +276,8 @@ impl<S: SettingsStore + 'static> App<S> {
             log::debug!("Got all available monitors: {:?}", self.monitors);
 
             self.window_pos = window
+                // NOTE: this is the top-left corner of the window relative to teh top-left corner of the desktop
+                // the desktop's top-left corner is the `position` of the monitor at the top-left of the desktop
                 .outer_position()
                 .map(|p| Point::new(p.x, p.y))
                 .unwrap_or_default();
@@ -758,7 +761,22 @@ fn create_gl_context(
     }
 }
 
-fn get_current_monitor(monitors: &[MonitorHandle], window_pos: Point) -> Option<MonitorHandle> {
+/// Find out which monitor a given point (window position) resides in.
+///
+/// Each monitor has a `position()` method that returns the monitor's top-left
+/// corner in the "desktop space". That's the rectangle fitting all their
+/// monitors in their arrangement with zero being the top-most point of the
+/// top-most monitor and the left-most point of the left-most monitor.
+///
+/// `window_pos_in_desktop_space` is a point within that "desktop space",
+/// denoting the top-left point of the window being tested.
+///
+/// The coordinates grow rightwards and downwards just like the coordinates
+/// within a single window do.
+fn get_current_monitor(
+    monitors: &[MonitorHandle],
+    window_pos_in_desktop_space: Point,
+) -> Option<MonitorHandle> {
     for monitor in monitors {
         let monitor_pos = {
             let pos = monitor.position();
@@ -769,13 +787,14 @@ fn get_current_monitor(monitors: &[MonitorHandle], window_pos: Point) -> Option<
             Point::new(dim.width as i32, dim.height as i32)
         };
 
-        let monitor_bottom_left = monitor_pos + monitor_dimensions;
-        if window_pos >= monitor_pos && window_pos < monitor_bottom_left {
+        if Rectangle::from_point_and_size(monitor_pos, monitor_dimensions)
+            .contains_excluding_bottom_right(window_pos_in_desktop_space)
+        {
             return Some(monitor.clone());
         }
     }
 
-    monitors.iter().next().cloned()
+    monitors.first().cloned()
 }
 
 pub fn main_loop<S>(

--- a/src/game.rs
+++ b/src/game.rs
@@ -730,8 +730,8 @@ fn process_game(
         }
 
         // NOTE: Show the path from the player to the mouse pointer
-        let mouse_inside_map =
-            state.mouse.tile_pos >= (0, 0) && state.mouse.tile_pos < state.map_size;
+        let mouse_inside_map = Rectangle::from_size(state.map_size)
+            .contains_excluding_bottom_right(state.mouse.tile_pos);
 
         let visible = state.mouse_world_position().inside_circular_area(
             state.player.pos,

--- a/src/level.rs
+++ b/src/level.rs
@@ -96,8 +96,8 @@ pub struct Level {
 
 impl Level {
     pub fn new(width: i32, height: i32) -> Level {
-        let dimensions = (width, height).into();
-        assert!(dimensions > (0, 0));
+        let dimensions = Point::new(width, height);
+        assert!(dimensions.is_positive());
         let map_size = (width * height) as usize;
         Level {
             dimensions,

--- a/src/point.rs
+++ b/src/point.rs
@@ -1,7 +1,7 @@
 #![allow(missing_copy_implementations)]
 
 use std::{
-    cmp::{Ordering, max},
+    cmp::max,
     fmt::{self, Display, Error, Formatter},
     ops::{Add, AddAssign, Div, Mul, Sub},
 };
@@ -52,6 +52,11 @@ impl Point {
 
     pub fn is_zero(self) -> bool {
         self.x == 0 && self.y == 0
+    }
+
+    /// Both components are positive (non-zero) numbers.
+    pub fn is_positive(self) -> bool {
+        self.x > 0 && self.y > 0
     }
 }
 
@@ -107,31 +112,6 @@ impl Sub for Point {
     }
 }
 
-impl PartialOrd for Point {
-    fn partial_cmp(&self, _other: &Point) -> Option<Ordering> {
-        // NOTE: I don't know that's the difference between this one
-        // and the more explicit fn below. So let's just crash here
-        // and see if and when we ever hit this.
-        unimplemented!();
-    }
-
-    fn lt(&self, other: &Point) -> bool {
-        self.x < other.x && self.y < other.y
-    }
-
-    fn le(&self, other: &Point) -> bool {
-        self.x <= other.x && self.y <= other.y
-    }
-
-    fn gt(&self, other: &Point) -> bool {
-        self.x > other.x && self.y > other.y
-    }
-
-    fn ge(&self, other: &Point) -> bool {
-        self.x >= other.x && self.y >= other.y
-    }
-}
-
 impl Add<(i32, i32)> for Point {
     type Output = Self;
 
@@ -161,33 +141,6 @@ impl PartialEq<(i32, i32)> for Point {
     fn eq(&self, other: &(i32, i32)) -> bool {
         let other: Point = (*other).into();
         self == &other
-    }
-}
-
-impl PartialOrd<(i32, i32)> for Point {
-    fn partial_cmp(&self, other: &(i32, i32)) -> Option<Ordering> {
-        let other: Point = (*other).into();
-        self.partial_cmp(&other)
-    }
-
-    fn lt(&self, other: &(i32, i32)) -> bool {
-        let other: Point = (*other).into();
-        self < &other
-    }
-
-    fn le(&self, other: &(i32, i32)) -> bool {
-        let other: Point = (*other).into();
-        self <= &other
-    }
-
-    fn gt(&self, other: &(i32, i32)) -> bool {
-        let other: Point = (*other).into();
-        self > &other
-    }
-
-    fn ge(&self, other: &(i32, i32)) -> bool {
-        let other: Point = (*other).into();
-        self >= &other
     }
 }
 
@@ -431,68 +384,5 @@ mod test {
             }
         }
         assert_eq!(actual, expected);
-    }
-
-    #[test]
-    fn test_point_comparison() {
-        assert!(Point::new(1, 1) > Point::new(0, 0));
-        assert!(Point::new(0, 0) < Point::new(1, 1));
-
-        assert!(Point::new(1, 1) >= Point::new(0, 0));
-        assert!(Point::new(1, 1) <= Point::new(1, 1));
-
-        assert_eq!(Point::new(1, 0) > Point::new(0, 1), false);
-        assert_eq!(Point::new(0, 1) > Point::new(1, 0), false);
-        assert_eq!(Point::new(1, 0) >= Point::new(0, 1), false);
-        assert_eq!(Point::new(0, 1) >= Point::new(1, 0), false);
-
-        assert_eq!(Point::new(1, 0) > Point::new(0, 0), false);
-        assert_eq!(Point::new(0, 1) > Point::new(0, 0), false);
-
-        assert!(Point::new(1, 0) >= Point::new(0, 0));
-        assert!(Point::new(0, 1) >= Point::new(0, 0));
-    }
-
-    #[test]
-    fn test_point_tuple_comparison() {
-        assert!(Point::new(1, 1) > (0, 0));
-        assert!(Point::new(0, 0) < (1, 1));
-
-        assert!(Point::new(1, 1) >= (0, 0));
-        assert!(Point::new(1, 1) <= (1, 1));
-
-        assert_eq!(Point::new(1, 0) > (0, 1), false);
-        assert_eq!(Point::new(0, 1) > (1, 0), false);
-        assert_eq!(Point::new(1, 0) >= (0, 1), false);
-        assert_eq!(Point::new(0, 1) >= (1, 0), false);
-
-        assert_eq!(Point::new(1, 0) > (0, 0), false);
-        assert_eq!(Point::new(0, 1) > (0, 0), false);
-
-        assert!(Point::new(1, 0) >= (0, 0));
-        assert!(Point::new(0, 1) >= (0, 0));
-    }
-
-    #[test]
-    fn test_point_bound_checking() {
-        let top_left_corner = Point::new(0, 0);
-        let display_size = Point::new(10, 10);
-        let within_bounds = |pos| pos >= top_left_corner && pos < display_size;
-
-        assert!(within_bounds(Point::new(0, 0)));
-        assert!(within_bounds(Point::new(1, 0)));
-        assert!(within_bounds(Point::new(0, 1)));
-        assert!(within_bounds(Point::new(1, 1)));
-        assert!(within_bounds(Point::new(3, 4)));
-        assert!(within_bounds(Point::new(9, 9)));
-        assert!(within_bounds(Point::new(2, 9)));
-        assert!(within_bounds(Point::new(9, 2)));
-
-        assert_eq!(within_bounds(Point::new(-1, 0)), false);
-        assert_eq!(within_bounds(Point::new(0, -1)), false);
-        assert_eq!(within_bounds(Point::new(-1, -1)), false);
-        assert_eq!(within_bounds(Point::new(1, 10)), false);
-        assert_eq!(within_bounds(Point::new(10, 1)), false);
-        assert_eq!(within_bounds(Point::new(10, 10)), false);
     }
 }

--- a/src/rect.rs
+++ b/src/rect.rs
@@ -20,7 +20,7 @@ impl Rectangle {
     }
 
     pub fn from_point_and_size(top_left: Point, size: Point) -> Self {
-        let size = if size >= (0, 0) {
+        let size = if size.x >= 0 && size.y >= 0 {
             size
         } else {
             log::error!(
@@ -35,13 +35,17 @@ impl Rectangle {
         }
     }
 
+    pub fn from_size(size: Point) -> Self {
+        Self::from_point_and_size(Point::zero(), size)
+    }
+
     /// Create a new rectangle defined by its middle point and
     /// (half-width, half-height).
     ///
     /// The result will have dimensions `half_size.x` * 2, `half_size.y`
     /// * 2.
     pub fn center(center: Point, half_size: Point) -> Self {
-        let half_size = if half_size >= (0, 0) {
+        let half_size = if half_size.x >= 0 && half_size.y >= 0 {
             half_size
         } else {
             log::error!(
@@ -94,8 +98,26 @@ impl Rectangle {
     /// Returns `true` if the point is within the areas specified by
     /// the rectangle. The mach is inclusive, so a `Rectangle`
     /// contains its `top_left` and `bottom_right` corners.
-    pub fn contains(self, point: Point) -> bool {
-        point >= self.top_left && point <= self.bottom_right
+    pub fn contains_inclusive(self, point: Point) -> bool {
+        point.x >= self.top_left.x
+            && point.x <= self.bottom_right.x
+            && point.y >= self.top_left.y
+            && point.y <= self.bottom_right.y
+    }
+
+    /// Returns `true` if the point is within the rectangle's area, except for
+    /// the right-most and bottom-most edges.
+    ///
+    /// I.e. includes the top-left corner but excludes the bottom-right one.
+    ///
+    /// This is useful for things like 0-based display coordinates. Where e.g. a
+    /// 1080p display would include points (0, 0), but exclude any (1920, ?) and
+    /// (?, 1080) points.
+    pub fn contains_excluding_bottom_right(self, point: Point) -> bool {
+        point.x >= self.top_left.x
+            && point.x < self.bottom_right.x
+            && point.y >= self.top_left.y
+            && point.y < self.bottom_right.y
     }
 
     /// Returns `true` if the two rectangles have at least one `Point`
@@ -186,5 +208,45 @@ mod tests {
         let rect = Rectangle::from_point_and_size((5, 7).into(), (2, 2).into());
         assert_eq!(rect.size(), Point::new(2, 2));
         assert_eq!(rect.points().count(), 4);
+    }
+
+    #[test]
+    fn smallest_rect_contains_inclusive() {
+        let rect = Rectangle::from_size(Point::new(1, 1));
+        assert!(rect.contains_inclusive(Point::zero()));
+        assert!(!rect.contains_inclusive(Point::new(1, 1)));
+        assert!(!rect.contains_inclusive(Point::new(0, 1)));
+        assert!(!rect.contains_inclusive(Point::new(1, 0)));
+    }
+
+    #[test]
+    fn rect_size_1_contains_inclusive() {
+        let rect = Rectangle::from_size(Point::new(2, 2));
+        assert!(rect.contains_inclusive(Point::zero()));
+        assert!(rect.contains_inclusive(Point::new(1, 1)));
+        assert!(rect.contains_inclusive(Point::new(0, 1)));
+        assert!(rect.contains_inclusive(Point::new(1, 0)));
+        assert!(!rect.contains_inclusive(Point::new(-1, 0)));
+        assert!(!rect.contains_inclusive(Point::new(0, -1)));
+        assert!(!rect.contains_inclusive(Point::new(1, 2)));
+        assert!(!rect.contains_inclusive(Point::new(2, 3)));
+    }
+
+    #[test]
+    fn smallest_rect_contains_exclusive() {
+        let rect = Rectangle::from_size(Point::new(1, 1));
+        // The rect contains exactly one point (0, 0) and that point is also the
+        // bottom-right point so it makes sense to return `false` here.
+        assert_eq!(rect.contains_excluding_bottom_right(Point::zero()), false)
+    }
+
+    #[test]
+    fn rect_size_1_contains_exclusive() {
+        let rect = Rectangle::from_size(Point::new(2, 2));
+        assert!(rect.contains_excluding_bottom_right(Point::zero()));
+        assert!(!rect.contains_excluding_bottom_right(Point::new(0, 1)));
+        assert!(!rect.contains_excluding_bottom_right(Point::new(1, 0)));
+        assert!(!rect.contains_excluding_bottom_right(Point::new(1, 1)));
+        assert!(!rect.contains_excluding_bottom_right(Point::new(2, 2)));
     }
 }

--- a/src/render.rs
+++ b/src/render.rs
@@ -112,7 +112,7 @@ pub fn render_game(
         .world
         .chunks(display_area)
         .flat_map(Chunk::cells)
-        .filter(|&(pos, _)| display_area.contains(pos))
+        .filter(|&(pos, _)| display_area.contains_inclusive(pos))
     {
         let display_pos = screen_coords_from_world(world_pos);
 
@@ -187,7 +187,7 @@ pub fn render_game(
         .world
         .chunks(display_area)
         .flat_map(Chunk::cells)
-        .filter(|&(pos, _)| display_area.contains(pos))
+        .filter(|&(pos, _)| display_area.contains_inclusive(pos))
     {
         // Render the irresistible background of a dose
         for item in &cell.items {

--- a/src/windows/sidebar.rs
+++ b/src/windows/sidebar.rs
@@ -7,6 +7,7 @@ use crate::{
     keys::KeyCode,
     player::Mind,
     point::Point,
+    rect::Rectangle,
     settings::Settings,
     state::State,
     ui,
@@ -507,7 +508,9 @@ pub fn process(
     if state.cheating {
         ui.label("CHEATING");
 
-        if state.mouse.tile_pos >= (0, 0) && state.mouse.tile_pos < display.size_without_padding() {
+        if Rectangle::from_size(display.size_without_padding())
+            .contains_excluding_bottom_right(state.mouse.tile_pos)
+        {
             ui.label(format!("Mouse px: {}", state.mouse.screen_pos));
             ui.label(format!("Mouse: {}", state.mouse.tile_pos));
         }

--- a/src/world.rs
+++ b/src/world.rs
@@ -233,7 +233,7 @@ impl World {
                         Shadows | Voices => false,
                         Hunger | Anxiety | Depression | Npc | Signpost => true, // NOTE: Signpost should never be generated on its own
                     };
-                    safe_area.contains(pos) || easy_monster
+                    safe_area.contains_inclusive(pos) || easy_monster
                 });
                 if remove_monster {
                     self.remove_monster(pos)
@@ -305,7 +305,7 @@ impl World {
                     let resist_area = Rectangle::center(pos, Point::from_i32(resist_radius));
 
                     // Bail if the player would be in the resist radius
-                    if resist_area.contains(player_info.pos) {
+                    if resist_area.contains_inclusive(player_info.pos) {
                         continue;
                     }
 
@@ -767,7 +767,7 @@ impl World {
     pub fn monsters(&self, area: Rectangle) -> impl Iterator<Item = &Monster> {
         self.chunks(area)
             .flat_map(Chunk::monsters)
-            .filter(move |m| m.alive() && area.contains(m.position))
+            .filter(move |m| m.alive() && area.contains_inclusive(m.position))
     }
 
     /// Return a mutable iterator over all monsters in the given area.
@@ -776,7 +776,7 @@ impl World {
     pub fn monsters_mut(&mut self, area: Rectangle) -> impl Iterator<Item = &mut Monster> {
         self.chunks_mut(area)
             .flat_map(Chunk::monsters_mut)
-            .filter(move |m| m.alive() && area.contains(m.position))
+            .filter(move |m| m.alive() && area.contains_inclusive(m.position))
     }
 
     pub fn positions_of_all_chunks(&self) -> Vec<Point> {


### PR DESCRIPTION
It turns out our implementation (and the whole conception of two-dimensional comparison) of `Point` is incompatible with the `PartialOrd` rules that must be followed.

So instead, we've replaced that with a few convenience functions:
* `Point::is_positive`
* `Rect::from_size`
* `Rect::contains_excluding_bottom_right`

And also renamed `Rect::contains` to `Rect::contains_inclusive` to make the distinction form the newly-added contains function explicit.

This also removes our only `unreachable!` macro call \o/

(which was what started this whole effort in the first place)