### PR TITLE
Remove `unreachable!`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -179,14 +179,14 @@ panic = "deny"
 manual_strip = "deny"
 await_holding_refcell_ref = "deny"
 unwrap_in_result = "deny"
+unreachable = "deny"
+unimplemented = "deny"
 
-# Require the `SAFETY` comments:
-undocumented_unsafe_blocks = "deny"
-# NOTE: these two deny direct indexing into arrays and the
-# `unreachable!` macro. These are definitely things that could crash
-# the game at runtime. But also a massive pain to code around.
+# NOTE: this denies direct indexing into arrays. That is definitely a thing that
+# could crash the game at runtime. But also a massive pain to code around.
 #
 # Worth reconsidering at some point, but keeping commented out for now.
 #indexing_slicing = "deny"
-#unreachable = "deny"
-unimplemented = "deny"
+
+# Require the `SAFETY` comments:
+undocumented_unsafe_blocks = "deny"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,7 +100,6 @@ default = ["dev", "sdl2-backend"]
 # NOTE: Add the `recording` feature to test/record the trailer mode
 prod = ["desktop", "sdl2-backend"]
 dev = ["desktop", "cheating", "replay", "stats", "verifications"]
-test = ["dev", "prod", "all-backends"]
 # NOTE: there's a runtime crash when both SDL2 and SDL3 backends are enabled.
 #
 # We keep the `all-backends` feature to be able to run cargo clippy

--- a/src/ai.rs
+++ b/src/ai.rs
@@ -36,30 +36,27 @@ pub fn lone_attacker_act(
     rng: &mut Random,
 ) -> (Update, Action) {
     if actor.ai_state == AIState::NoOp {
-        return noop_action(actor);
-    }
-    let distance = actor.position.tile_distance(player_info.pos);
-    let ai_state = if distance <= formula::CHASING_DISTANCE {
-        AIState::Chasing
+        noop_action(actor)
     } else {
-        AIState::Idle
-    };
-
-    let update = Update {
-        ai_state,
-        max_ap: actor.ap.max(),
-    };
-
-    let action = match ai_state {
-        AIState::Chasing => chasing_action(actor, player_info.pos),
-        AIState::Idle => {
+        let distance = actor.position.tile_distance(player_info.pos);
+        let (ai_state, action) = if distance <= formula::CHASING_DISTANCE {
+            let ai_state = AIState::Chasing;
+            let action = chasing_action(actor, player_info.pos);
+            (ai_state, action)
+        } else {
+            let ai_state = AIState::Idle;
             let destination = idle_destination(actor, world, rng, player_info.pos);
-            Action::Move(destination)
-        }
-        AIState::CheckingOut(destination) => Action::Move(destination),
-        AIState::NoOp => unreachable!(),
-    };
-    (update, action)
+            let action = Action::Move(destination);
+            (ai_state, action)
+        };
+
+        let update = Update {
+            ai_state,
+            max_ap: actor.ap.max(),
+        };
+
+        (update, action)
+    }
 }
 
 pub fn pack_attacker_act(
@@ -68,9 +65,6 @@ pub fn pack_attacker_act(
     world: &mut World,
     rng: &mut Random,
 ) -> (Update, Action) {
-    if actor.ai_state == AIState::NoOp {
-        return noop_action(actor);
-    }
     let player_distance = actor.position.tile_distance(player_info.pos);
     let ai_state = if player_distance <= formula::CHASING_DISTANCE {
         AIState::Chasing
@@ -109,7 +103,7 @@ pub fn pack_attacker_act(
             Action::Move(destination)
         }
         AIState::CheckingOut(destination) => Action::Move(destination),
-        AIState::NoOp => unreachable!(),
+        AIState::NoOp => Action::Move(actor.position),
     };
     (update, action)
 }

--- a/src/engine/headless.rs
+++ b/src/engine/headless.rs
@@ -85,9 +85,13 @@ where
 
         match update_result {
             RunningState::Running => {}
-            RunningState::NewGame(_new_state) => unreachable!(),
+            RunningState::NewGame(_new_state) => throw!(
+                "Unexpected `NewGame` update result. The headless mode doesn't accept user input and there should be no way to start a new game."
+            ),
             RunningState::Stopped => break,
-            RunningState::Skip => unreachable!(),
+            RunningState::Skip => throw!(
+                "Unexpected `Skip` update result. Frame skipping should already have been handled by now."
+            ),
         }
     }
 

--- a/src/engine/loop_state.rs
+++ b/src/engine/loop_state.rs
@@ -432,7 +432,11 @@ impl LoopState {
                 self.game_state = new_state;
             }
             RunningState::Stopped => return UpdateResult::QuitRequested,
-            RunningState::Skip => unreachable!(),
+            RunningState::Skip => {
+                wtf!(
+                    "Got `RunningState::Skip` even after they've all been exhausted. This shouldn't happen."
+                );
+            }
         }
 
         self.reset_inputs();

--- a/src/game.rs
+++ b/src/game.rs
@@ -1532,8 +1532,13 @@ fn process_player_action(
                 }
             }
 
-            Action::Attack(_, _) => {
-                unreachable!();
+            Action::Attack(destination, player_modifier) => {
+                log::error!(
+                    "Player tried to use the `Attack` action. This should not be possible (attack is done via moving). Destination: {:?}, player modifier: {:?}",
+                    destination,
+                    player_modifier
+                );
+                player.spend_ap(1);
             }
         }
     } else {
@@ -1792,19 +1797,24 @@ fn inventory_commands(key: Key) -> Option<Command> {
 
     for kind in Kind::iter() {
         let num_key = match inventory_key(kind) {
-            1 => D1,
-            2 => D2,
-            3 => D3,
-            4 => D4,
-            5 => D5,
-            6 => D6,
-            7 => D7,
-            8 => D8,
-            9 => D9,
-            _ => unreachable!("There should only ever be 9 item kinds at most."),
+            Some(1) => Some(D1),
+            Some(2) => Some(D2),
+            Some(3) => Some(D3),
+            Some(4) => Some(D4),
+            Some(5) => Some(D5),
+            Some(6) => Some(D6),
+            Some(7) => Some(D7),
+            Some(8) => Some(D8),
+            Some(9) => Some(D9),
+            _ => {
+                log::error!(
+                    "Unexpected inventory key for {kind}. There should only ever be 9 item kinds at most."
+                );
+                None
+            }
         };
 
-        if key.code == num_key {
+        if Some(key.code) == num_key {
             let command = match kind {
                 Kind::Food => Command::UseFood,
                 Kind::Dose => Command::UseDose,
@@ -1818,15 +1828,15 @@ fn inventory_commands(key: Key) -> Option<Command> {
     None
 }
 
-pub fn inventory_key(kind: item::Kind) -> u8 {
+pub fn inventory_key(kind: item::Kind) -> Option<u8> {
     // NOTE: use the order defined in `Kind::iter` so the keys always
     // correspond to the order we display the items in.
     for (index, current_kind) in item::Kind::iter().enumerate() {
         if current_kind == kind {
-            return (index + 1) as u8;
+            return Some((index + 1) as u8);
         }
     }
-    unreachable!()
+    None
 }
 
 fn kill_monster(monster_position: Point, world: &mut World, audio: &mut Audio) {
@@ -1855,7 +1865,6 @@ fn use_dose(
     use crate::{item::Kind::*, player::Modifier::*};
     log::debug!("Using dose");
     audio.play_sound(Effect::Explosion, Duration::from_millis(0));
-    // TODO: do a different explosion animation for the cardinal dose
     if let Intoxication { state_of_mind, .. } = item.modifier {
         let radius = if state_of_mind <= 100 { 4 } else { 6 };
         player.take_effect(item.modifier);
@@ -1880,11 +1889,22 @@ fn use_dose(
                 palette.explosion,
                 palette.shattering_explosion,
             )),
-            Food => unreachable!(),
+            Food => {
+                wtf!("Tried to use `Food` in `use_dose`. This shouldn't happen.");
+                Box::new(animation::SquareExplosion::new(
+                    player.pos,
+                    0,
+                    0,
+                    palette.explosion,
+                ))
+            }
         };
         *explosion_animation = Some(animation);
     } else {
-        unreachable!();
+        wtf!(
+            "Tried to use a dose but `item.modifier` was not of the `Intoxication` variant: {:?}",
+            item.modifier
+        );
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,12 +152,6 @@ pub fn run() -> Result<(), Box<dyn std::error::Error>> {
     use simplelog::{CombinedLogger, LevelFilter, SharedLogger, SimpleLogger, WriteLogger};
     use std::fs::File;
 
-    // Print out all environment variables:
-    log::info!("Environment variables:");
-    for (key, value) in std::env::vars() {
-        log::info!("{key}: {value}");
-    }
-
     let mut app = App::new(metadata::TITLE)
         .version(metadata::VERSION)
         .author(metadata::AUTHORS)
@@ -269,6 +263,12 @@ pub fn run() -> Result<(), Box<dyn std::error::Error>> {
     // NOTE: ignore the loggers if we can't initialise them. The game
     // should still be able to function.
     let _ = CombinedLogger::init(loggers);
+
+    // Print out all environment variables:
+    log::trace!("Environment variables:");
+    for (key, value) in std::env::vars() {
+        log::trace!("{key}: {value}");
+    }
 
     log_panics::init();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,28 @@ macro_rules! throw {
     };
 }
 
+/// Panic with message in non-prod mode (regardless if debug or release). Print
+/// an error and keep going in *prod*, i.e. `cfg!(feature = "prod")`.
+///
+/// Takes optional formatting arguments similar to `panic!`, `println!` etc.
+macro_rules! wtf {
+    ($message:expr) => {
+	if std::cfg!(feature = "prod") {
+            log::error!($message);
+	} else {
+	    panic!($message);
+	}
+    };
+    ($message:expr, $($arg:tt)+) => {
+	if std::cfg!(feature = "prod") {
+            log::error!($message, $($arg)+);
+	} else {
+	    panic!($message, $($arg)+);
+	}
+    };
+
+}
+
 pub mod ai;
 pub mod animation;
 pub mod audio;

--- a/src/monster.rs
+++ b/src/monster.rs
@@ -85,7 +85,13 @@ impl CompanionBonus {
             0 => DoubleWillGrowth,
             1 => HalveExhaustion,
             2 => ExtraActionPoint,
-            _ => unreachable!(),
+            unexpected => {
+                wtf!(
+                    "`range_inclusive` should only have returned a number from 0..=2. Got: `{unexpected}` instead."
+                );
+                // NOTE: this is a fallback value:
+                DoubleWillGrowth
+            }
         }
     }
 }

--- a/src/pathfinding.rs
+++ b/src/pathfinding.rs
@@ -230,6 +230,9 @@ impl PartialOrd for State {
 
 #[cfg(test)]
 mod test {
+    // Panics in test code are fine. They're just a different kind of assert.
+    #![allow(clippy::panic)]
+
     use super::Path;
     use crate::{
         blocker::Blocker,
@@ -302,7 +305,11 @@ mod test {
                     's' => Empty,
                     'd' => Empty,
                     'x' => Tree,
-                    _ => unreachable!(),
+                    unexpected => {
+                        panic!(
+                            "Unexpected tile character value: `{unexpected}`. This probably means the test board has a character that's not supposed to be there."
+                        );
+                    }
                 };
                 let pos = Point { x, y };
                 if let Some(cell) = world.cell_mut(pos) {

--- a/src/windows/sidebar.rs
+++ b/src/windows/sidebar.rs
@@ -275,8 +275,12 @@ pub fn process(
             VisualStyle::Graphical => Texture::Tilemap,
             VisualStyle::Textual => Texture::Glyph,
         };
+        let inventory_key = game::inventory_key(kind).unwrap_or_else(|| {
+	    log::error!("`inventory_key` for item `{kind}` returned `None`. This shouldn't happen as all inventory items should have a unique key from `1..=9` assigned. Falling back to `1`.");
+	    1
+	});
         let button = ui::ImageTextButton::new(texture, button_label)
-            .prefix_text(format!("[{}]", game::inventory_key(kind)))
+            .prefix_text(format!("[{}]", inventory_key))
             .tile(graphic)
             .tile_offset_px(tile_offset)
             .image_color(item_color)


### PR DESCRIPTION
This lays the ground work and makes changes so that the `unreachable!` macro is no longer used and we forbid its future use with a deny clippy lint.

One more step towards preventing runtime crashes.