### PR TITLE
Improve the greyscale mode colours

### DIFF
--- a/src/palette.rs
+++ b/src/palette.rs
@@ -217,7 +217,7 @@ impl Palette {
 
             explored_background: BLACK,
             unexplored_background: BLACK,
-            dim_background: DARKEST_GREY,
+            dim_background: DARKER_GREY,
 
             exhaustion_animation: BLACK,
             fade_to_black_animation: BLACK,
@@ -245,7 +245,7 @@ impl Palette {
             dose: WHITE,
             strong_dose: WHITE,
             shattering_dose: WHITE,
-            dose_irresistible_background: DARK_GREY,
+            dose_irresistible_background: DARKEST_GREY,
             explosion: DARK_GREY,
             shattering_explosion: WHITE,
 
@@ -255,9 +255,9 @@ impl Palette {
 
             tree: [GREY, GREY, GREY],
 
-            empty_tile_ground: GREY,
-            empty_tile_leaves: GREY,
-            empty_tile_twigs: GREY,
+            empty_tile_ground: DARK_GREY,
+            empty_tile_leaves: DARK_GREY,
+            empty_tile_twigs: DARK_GREY,
         }
     }
 

--- a/src/palette/greyscale.rs
+++ b/src/palette/greyscale.rs
@@ -4,4 +4,5 @@ use crate::color::Color;
 
 pub const GREY: Color = Color {r: 187, g: 187, b: 187};
 pub const DARK_GREY: Color = Color {r: 85, g: 85, b: 85};
+pub const DARKER_GREY: Color = Color {r: 65, g: 65, b: 65};
 pub const DARKEST_GREY: Color = Color {r: 45, g: 45, b: 45};


### PR DESCRIPTION
There were a lot of things that were difficult or impossible to see or tell apart in the greyscale mode. This changes the colours in that palette to make it easier to see what's going on.

This tones down the "fog of war" colour, the dose irresistible background and the "empty" tiles with actual images. As in, all those get darker.

That makes the food stand out more and makes the map more legible.

The palette didn't have enough options, so we've introduced a few new colours.